### PR TITLE
Add field to WorkPage for external URL

### DIFF
--- a/core/migrations/0026_workpage_client_external_url.py
+++ b/core/migrations/0026_workpage_client_external_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0025_auto_20160218_0102'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='workpage',
+            name='client_external_url',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -66,6 +66,9 @@ class WorkPage(Page):
                            help_text="Background image for homepage stripe. Should be blurred or low entropy for light text to be legible on it.",
                            related_name="+")
     client_name = models.CharField(max_length=255)
+    client_external_url = models.CharField(max_length=255, null=True, blank=True,
+                            help_text="External URL of the project.",
+                            verbose_name="Client External URL")
     project_date = models.DateField(blank=True, null=True,
                             help_text="Approximate date of project completion.")
     testimonial = RichTextField(blank=True)
@@ -86,6 +89,7 @@ class WorkPage(Page):
         MultiFieldPanel([
             ImageChooserPanel('screenshot'),
             FieldPanel('client_name'),
+            FieldPanel('client_external_url'),
             FieldPanel('project_date'),
         ], "Project Details")
     ]

--- a/core/templates/core/work_page.html
+++ b/core/templates/core/work_page.html
@@ -30,6 +30,12 @@
 				{% endif %}
 				<div class="margin-trailer-dbl">
 					{{ page.body }}
+
+					{% if self.client_external_url %}
+					<a href="{{ self.client_external_url }}" target="_blank" class="btn btn-sm btn-secondary">
+						See Work <i class="fa fa-chevron-right"></i>
+					</a>
+					{% endif %}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
* Add “See Work” button on the bottom of work pages to take the visitor
  to an external 3rd party (e.g. client’s project), if the field is set.

y/n/maybe so? Maybe a different button label other then "See Work"?