### PR TITLE
Put author images back on blog pages

### DIFF
--- a/core/templates/core/blog_page.html
+++ b/core/templates/core/blog_page.html
@@ -58,7 +58,7 @@
 							<div class="media-left p-r-1">
 								{% if page.author.picture %}
 									{% image page.author.picture fill-150x150 as author_image %}
-									<img src="{{ author_image.url }}" alt="{{ page.author.picture.title }}" width=100 height=100 class="media-object img-fluid img-circle"/>
+									<img src="{{ author_image.url }}" alt="{{ page.author.picture.title }}" width=100 height=100 class="media-object img-circle"/>
 								{% endif %}
 							</div>
 							<div class="media-body">


### PR DESCRIPTION
Superfluous img-fluid was making them not appear.