### PR TITLE
Add flag to tell django-storages to gzip content.

### DIFF
--- a/littleweaverweb/settings/production.py
+++ b/littleweaverweb/settings/production.py
@@ -10,6 +10,17 @@ DATABASES['default'] =  dj_database_url.config()
 
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
+AWS_IS_GZIPPED = True
+
+# Add missing content types to the list of types
+# that should be gzipped.
+GZIP_CONTENT_TYPES = (
+ 'text/css',
+ 'application/javascript',
+ 'application/x-javascript',
+ 'text/javascript'
+)
+
 AWS_STORAGE_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME")
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
There's not a lot of explicit documentation on this front, but it looks
like we need a couple more settings flags to actually get gzipped
assets. See here:

https://bitbucket.org/david/django-storages/src/f153a70ba254dc129d9403546809a02256ef75b5/storages/backends/s3boto.py?at=default&fileviewer=file-view-default#s3boto.py-235

Pertains to #39 