### PR TITLE
less transparency on the navbar

### DIFF
--- a/core/static/css/modules/_site-header.sass
+++ b/core/static/css/modules/_site-header.sass
@@ -6,4 +6,4 @@
 		left: 0
 		right: 0
 		z-index: 1
-		background-color: rgba($black-almost, .35)
+		background-color: rgba($black-almost, .5)


### PR DESCRIPTION
Closes #86 

Makes the navbar less transparent so that it looks better when there's no banner image.

It would be nice to make it have a different class when there's no banner image but that would require entirely restructuring the templates, and I don't think that's worth it at the moment.