### PR TITLE
Update Wagtail, Django, fix WorkPage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,14 @@ The first time you run, you'll need to run migrations and create a superuser:
     python manage.py migrate           # Create/sync the database.
     python manage.py createsuperuser   # Create an initial user.
 
+``base.py`` will use sqlite3 by default.
+You can use postgres with the ``DATABASE_URL`` environment variable.
+
+.. code:: bash
+
+    createdb lww
+    DATABASE_URL=postgres:///lww python manage.py migrate
+
 Get it running
 --------------
 

--- a/core/blocks.py
+++ b/core/blocks.py
@@ -28,7 +28,7 @@ class CodeBlock(blocks.StructBlock):
     class Meta:
         icon = 'code'
 
-    def render(self, value):
+    def render(self, value, **kwargs):
         src = value['code'].strip('\n')
         lang = value['language']
 
@@ -58,7 +58,7 @@ class MarkdownBlock(blocks.TextBlock):
     class Meta:
         icon = 'code'
 
-    def render_basic(self, value):
+    def render_basic(self, value, **kwargs):
         md = markdown(
             value,
             [

--- a/core/models.py
+++ b/core/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 from django.shortcuts import render, get_object_or_404
 from django.utils.six import text_type
-from modelcluster.fields import ParentalKey
+from modelcluster.fields import ParentalKey, ParentalManyToManyField
 from modelcluster.contrib.taggit import ClusterTaggableManager
 from taggit.models import TaggedItemBase
 from wagtail.contrib.wagtailroutablepage.models import RoutablePageMixin, route
@@ -132,8 +132,8 @@ class WorkPage(Page):
     link = models.URLField(max_length=255, null=True, blank=True,
                             help_text="External URL of the project.",
                             verbose_name="Client External URL")
-    services = models.ManyToManyField(Service, blank=True)
-    technologies = models.ManyToManyField(Technology, blank=True)
+    services = ParentalManyToManyField(Service, blank=True)
+    technologies = ParentalManyToManyField(Technology, blank=True)
 
     # Details for teasers on other pages:
     teaser_title = models.CharField(max_length=255, blank=True)

--- a/littleweaverweb/settings/base.py
+++ b/littleweaverweb/settings/base.py
@@ -1,6 +1,7 @@
 import os
 from os.path import abspath, dirname, join
 
+import dj_database_url
 from django.conf import global_settings
 
 # Absolute filesystem path to the Django project directory:
@@ -70,27 +71,17 @@ WSGI_APPLICATION = 'littleweaverweb.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
-
-# SQLite (simplest install)
-DATABASES = {
-    'default': {
+DATABASES = dict()
+# https://github.com/kennethreitz/dj-database-url
+db_configuration = dj_database_url.config()
+if db_configuration:
+    DATABASES['default'] = db_configuration
+else:
+    print('No DATABASE_URL specified, using sqlite.')
+    DATABASES['default'] = {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': join(PROJECT_ROOT, 'db.sqlite3'),
     }
-}
-
-# PostgreSQL (Recommended, but requires the psycopg2 library and Postgresql development headers)
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-#         'NAME': 'littleweaverweb',
-#         'USER': 'postgres',
-#         'PASSWORD': '',
-#         'HOST': '',  # Set to empty string for localhost.
-#         'PORT': '',  # Set to empty string for default.
-#         'CONN_MAX_AGE': 600,  # number of seconds database connections should persist for
-#     }
-# }
 
 
 # Internationalization

--- a/littleweaverweb/settings/base.py
+++ b/littleweaverweb/settings/base.py
@@ -71,17 +71,10 @@ WSGI_APPLICATION = 'littleweaverweb.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
-DATABASES = dict()
 # https://github.com/kennethreitz/dj-database-url
-db_configuration = dj_database_url.config()
-if db_configuration:
-    DATABASES['default'] = db_configuration
-else:
-    print('No DATABASE_URL specified, using sqlite.')
-    DATABASES['default'] = {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': join(PROJECT_ROOT, 'db.sqlite3'),
-    }
+DATABASES = {
+	'default': dj_database_url.config(default='sqlite:///db.sqlite3')
+}
 
 
 # Internationalization

--- a/littleweaverweb/settings/base.py
+++ b/littleweaverweb/settings/base.py
@@ -58,8 +58,10 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
@@ -141,15 +143,14 @@ TEMPLATES = [
             'context_processors': [
                 # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
                 # list if you haven't customized them:
-                'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.debug',
+                'django.template.context_processors.request',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
+                'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'django.core.context_processors.request',
-                'wagtail.contrib.settings.context_processors.settings',
             ],
             'debug': True,
         },

--- a/littleweaverweb/settings/production.py
+++ b/littleweaverweb/settings/production.py
@@ -1,12 +1,9 @@
 from .base import *
-import dj_database_url
 
 # Disable debug mode
 
 DEBUG = False
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG
-
-DATABASES['default'] =  dj_database_url.config()
 
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ django-appconf==1.0.1
 django-compressor==2.0
 django-compressor-autoprefixer==0.1.0
 django-libsass==0.6
-django-modelcluster==1.1
+django-modelcluster==3.0.1
 django-storages==1.1.8
-django-taggit==0.18.1
+django-taggit==0.22.1
 django-treebeard==4.0.1
 djangorestframework==3.3.3
 gunicorn==19.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 beautifulsoup4==4.4.1
 boto==2.38.0
-dj-database-url==0.3.0
+dj-database-url==0.4.2
 dj-static==0.0.6
-Django==1.9.6
+Django==1.11.1
 django-appconf==1.0.1
 django-compressor==2.0
 django-compressor-autoprefixer==0.1.0
@@ -17,7 +17,7 @@ html5lib==0.9999999
 libsass==0.11.0
 markdown>=2.0,<3.0
 Pillow==3.2.0
-psycopg2==2.5.1
+psycopg2==2.7.1
 pygments>=2.0,<3.0
 python-http-client==1.2.3
 pytz==2016.4
@@ -33,7 +33,7 @@ static==0.4
 static3==0.6.1
 unicodecsv==0.12.0
 Unidecode==0.4.19
-wagtail==1.4.5
+wagtail==1.10
 Wand==0.4.2
 Willow==0.3.1
 https://github.com/littleweaver/django-bootstrap/tarball/d323bf6


### PR DESCRIPTION
Note: merge #94 first, this branches off.

* Closes #91 
* Update Wagtail from 1.4.5 to 1.10
* Update Django from 1.9.6 to 1.11.1
* Update misc Python packages to support the update
* Fixes `WorkPage` creation by switching to `modelcluster`'s `ParentalManyToManyField`