### PR TITLE
Fix missing Google analytics

### DIFF
--- a/core/templates/core/layouts/base.html
+++ b/core/templates/core/layouts/base.html
@@ -1,5 +1,6 @@
 {% load compress staticfiles wagtailuserbar %}
-{% load wagtailcore_tags wagtailimages_tags %}
+{% load wagtailsettings_tags wagtailcore_tags wagtailimages_tags %}
+{% get_settings %}
 
 <!DOCTYPE html>
 <html class="no-js">


### PR DESCRIPTION
The Wagtail update introduced a necessary get_settings template tag call
that was missing.

Did not see this in
https://github.com/wagtail/wagtail/blob/master/CHANGELOG.txt
:(