### PR TITLE
Install Battle for the Net widget

### DIFF
--- a/core/templates/core/layouts/base.html
+++ b/core/templates/core/layouts/base.html
@@ -89,5 +89,13 @@
 			<script type="text/javascript" src="{% static 'js/littleweaverweb.js' %}"></script>
 		{% endcompress %}
 		{% block extra_js %}{% endblock %}
+		<script type="text/javascript">
+			var _bftn_options = {
+				theme: 'slow',
+				delay: 500,
+				disableGoogleAnalytics: true,
+			};
+		</script>
+		<script src="https://widget.battleforthenet.com/widget.js" async></script>
 	</body>
 </html>


### PR DESCRIPTION
* This widget will only appear on July 12th 2017.
* It loads on every page.
* https://github.com/fightforthefuture/battleforthenet-widget
* You can force displaying the widget with a hash URL like this http://localhost:8000/#ALWAYS_SHOW_BFTN_WIDGET
* This modal loads an iframe on a secure origin.