### PR TITLE
Fix uploading and searching images in admin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ unicodecsv==0.12.0
 Unidecode==0.4.19
 wagtail==1.10
 Wand==0.4.2
-Willow==0.3.1
+Willow==1.0
 https://github.com/littleweaver/django-bootstrap/tarball/d323bf6


### PR DESCRIPTION
Closes #100 

Upgrading Wagtail required an upgrade to Willow. This commit fixes
issues like this:

```TypeError: save_as_jpeg() got an unexpected keyword argument 'progressive'```